### PR TITLE
fix: 이름 겹치는 메서드 삭제

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -1,21 +1,15 @@
 package SamwaMoney.TimeTableArtist.Timetable.service;
 
-import SamwaMoney.TimeTableArtist.Class.domain.Class;
-import SamwaMoney.TimeTableArtist.Class.dto.ClassDto;
 import SamwaMoney.TimeTableArtist.Member.domain.Member;
 import SamwaMoney.TimeTableArtist.Member.repository.MemberRepository;
 import SamwaMoney.TimeTableArtist.Member.service.MemberService;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
-import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableFindResponseDto;
 import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableRequestDto;
 import SamwaMoney.TimeTableArtist.Timetable.repository.TimetableRepository;
-import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TablePlusComment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityNotFoundException;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -52,28 +46,5 @@ public class TimetableService {
     public Timetable findTimetableById(Long timetableId){
         return timetableRepository.findById(timetableId)
                 .orElseThrow(()->new EntityNotFoundException("해당 시간표가 존재하지 않습니다."));
-    }
-}
-
-    // 내 시간표 조회
-    public List<Class> findClassListByTimetableId(Long timetableId) {
-        return timetableRepository.findAllByTimetableId(timetableId);
-    }
-
-    // 시간표 ID로 시간표를 찾기
-    public TimetableFindResponseDto findTimetableById(Long timetableId) {
-        Timetable timetable = timetableRepository.findById(timetableId)
-                .orElseThrow(() -> new IllegalArgumentException("시간표를 찾을 수 없습니다. 시간표 ID: " + timetableId));
-
-        List<Class> classList = timetable.getClassList(); // 해당 시간표에 속한 수업들을 가져옴
-        TimetableFindResponseDto responseDto = TimetableFindResponseDto.from(timetable, classList); // 시간표와 수업 리스트를 TimetableFindResponseDto로 변환
-        return responseDto;
-    }
-
-    // 수업 리스트를 ClassDto 리스트로 변환하는 메서드
-    private List<ClassDto> convertClassListToClassDtoList(List<Class> classList) {
-        return classList.stream()
-                .map(ClassDto::from)
-                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
# 구현 기능
- 머지 과정에서 잘못 병합된 것으로 보이는 `timetableService` 내부 메서드를 정리했습니다.

# 구현 상태
- 기존 코드 모두 정상 작동
<img width="1392" alt="스크린샷 2023-07-22 오후 10 56 58" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/77741296/39c7da0f-e4b0-4225-b409-b6a5c2056922">
<img width="1392" alt="스크린샷 2023-07-22 오후 10 59 54" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/77741296/0dfe55bf-b9ba-4806-9e5c-74ed1a151e71">
<img width="1392" alt="스크린샷 2023-07-22 오후 11 01 20" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/77741296/f869d949-06c5-4388-8ca8-518b7ac3074a">

