### PR TITLE
[노하은]로그아웃 & 토큰 리프레시 기능 추가 완료

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/domain/RefreshToken.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/domain/RefreshToken.java
@@ -1,0 +1,26 @@
+package SamwaMoney.TimeTableArtist.Member.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Setter
+@Getter
+public class RefreshToken {
+    // 고유 키
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long refreshTokenId;
+
+    // 이 토큰의 주인인 회원의 고유 키
+    @Column(nullable = false)
+    private Long memberId;
+
+    // 이 토큰의 값
+    @Column(nullable = false)
+    private String value;
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/dto/MemberLoginResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/dto/MemberLoginResponseDto.java
@@ -1,0 +1,23 @@
+package SamwaMoney.TimeTableArtist.Member.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberLoginResponseDto {
+    private Long memberId;
+    private String username;
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public MemberLoginResponseDto(Long memberId, String username, String accessToken, String refreshToken) {
+        this.memberId = memberId;
+        this.username = username;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/dto/RefreshTokenRequestDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,10 @@
+package SamwaMoney.TimeTableArtist.Member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequestDto {
+    private String refreshToken;
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/repository/RefreshTokenRepository.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package SamwaMoney.TimeTableArtist.Member.repository;
+
+import SamwaMoney.TimeTableArtist.Member.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository  extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByValue(String value);
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/service/RefreshTokenService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Member/service/RefreshTokenService.java
@@ -1,0 +1,31 @@
+package SamwaMoney.TimeTableArtist.Member.service;
+
+import SamwaMoney.TimeTableArtist.Member.domain.RefreshToken;
+import SamwaMoney.TimeTableArtist.Member.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken addRefreshToken(RefreshToken refreshToken) {
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    @Transactional(readOnly = true)
+    public RefreshToken findRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByValue(refreshToken)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 RefreshToken입니다!"));
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        RefreshToken foundRefreshToken = refreshTokenRepository.findByValue(refreshToken)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 RefreshToken입니다!"));
+        refreshTokenRepository.delete(foundRefreshToken);
+    }
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/configuration/SecurityConfig.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/configuration/SecurityConfig.java
@@ -26,8 +26,8 @@ public class SecurityConfig {
                 .csrf().disable()
                 .cors().and()
                 .authorizeRequests()
-                .antMatchers("/members/signup", "/members/login").permitAll()    // 회원가입, 로그인은 무조건 허용
-                .antMatchers(HttpMethod.POST, "/members/**").authenticated() // /members/로 시작하는 다른 URI의 POST 요청은 모두 인증 요구
+                .antMatchers("/members/signup", "/members/login", "/members/refreshtoken").permitAll()    // 회원가입, 로그인은 무조건 허용
+                .antMatchers(HttpMethod.POST, "/members/**").authenticated() // 모든 POST 요청과, /members/로 시작하는 다른 URI의 모든 요청은 인증 요구
                 .and()
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // JWT를 사용하므로 stateless

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/utils/JwtUtil.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/utils/JwtUtil.java
@@ -19,9 +19,10 @@ public class JwtUtil {
                 .getBody().get("userName", String.class);
     }
 
-    public static String createToken (String userName, String key, long expireTimeMs) {
+    // token을 만드는 함수 (createAccessToken과 createRefreshToken이 이 함수를 호출함)
+    public static String createToken (String username, String key, long expireTimeMs) {
         Claims claims = Jwts.claims();  // 일종의 Map. 토큰 생성에 필요한 데이터를 담아두는 공간.
-        claims.put("userName", userName);   // 회원명을 저장
+        claims.put("username", username);   // 회원명을 저장
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -31,5 +32,22 @@ public class JwtUtil {
                 .compact()
                 ;
 
+    }
+
+    // AccessToken을 만드는 함수
+    public static String createAccessToken(String userName, String key, long expireTimeMs) {
+        return createToken(userName, key, expireTimeMs);
+    }
+
+    // RefreshToken을 만드는 함수
+    public static String createRefreshToken (String userName, String key, long expireTimeMs) {
+        return createToken(userName, key, expireTimeMs);
+    }
+
+    public static Claims parseRefreshToken(String value, String key) {
+        return Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(value)
+                .getBody();
     }
 }


### PR DESCRIPTION
# 구현 기능
- 로그아웃 기능을 추가하였습니다
- 토큰 리프레시 기능을 추가하였습니다

# 구현 상태
- 이전: 로그인 시 Access Token만 발급되었습니다
- 현재: 이제 로그인 시 Access Token과 Refresh Token이 함께 발급됩니다.<br><br>
- 이전: Access Token만 발급되었기 때문에, Access Token의 유효기간인 1시간보다 오래 로그인 상태를 유지할 수 없었습니다.
- 현재: 이제 Access Token이 만료되었을 때 프론트에서 토큰 리프레시 요청을 보내 로그인 상태를 유지할 수 있습니다. Refresh Token의 유효기간이 일주일이므로, 토큰 리프레시도 로그인 이후 7주일 동안 가능합니다.<br><br>
- Refresh Token을 사용하게 되었으므로 로그아웃 시 백 측에서 Refresh Token을 삭제하는 코드가 필요해졌습니다. 따라서 이를 추가하였습니다. 유저가 로그아웃을 누르면 프론트 측에서 Access Token을 삭제하여 즉시 접근권한이 박탈되고, 백 측에서는 Access Token을 재발급해주는 Refresh Token을 DB에서 삭제하여 더이상 토큰 리프레시(로그인 연장)을 할 수 없게 됩니다. 따라서 다시 로그인해 Refresh Token을 새로 발급받아야만 토큰 리프레시가 가능한 상태가 됩니다.<br><br>
- Postman 테스트 결과: https://sphenoid-latency-1e6.notion.site/20230724-Postman-d33fc7ec0a224bbaa296296b123ff6ca?pvs=4<br><br>
이번 개발로 인해 변경된 노션 문서:
- ![JWT 관련 사항](https://www.notion.so/efub/JWT-3a1a6e7a0290470ca1f03066346d0b96)에 Refresh Token의  유효기간 설명이 추가됨
- ![API 문서](https://www.notion.so/efub/7e4579a752c644a9be9d06e87eb8f1fc?v=451697bb988e49d884664e23687ff2f6) 내 Member의 로그인에 Response Body가 추가됨, 로그아웃 문서가 완성됨, 토큰 리프레시 문서가 추가됨
- ![application.yml 템플릿 (로컬 개발용)](https://www.notion.so/efub/application-yml-7dd39723696b41e68bb29d5f907004c2) 에 refresh-key가 추가됨

