### PR TITLE
[김혜빈] 시간표 table 좋아요

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/service/ReplyService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/service/ReplyService.java
@@ -9,6 +9,8 @@ import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import SamwaMoney.TimeTableArtist.Timetable.service.AllClassAlgoService;
 import SamwaMoney.TimeTableArtist.Timetable.service.TimetableService;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,9 +22,11 @@ import java.util.List;
 @AllArgsConstructor
 public class ReplyService {
     private final ReplyRepository replyRepository;
-    private final TimetableService timetableService;
     private final MemberService memberService;
     private final AllClassAlgoService allClassAlgoService;
+    @Autowired
+    @Lazy
+    private TimetableService timetableService;
 
     public Long createReply(Long timetableId, ReplyRequestDto requestDto) {
         Timetable timetable = timetableService.findTimetableById(timetableId);

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
@@ -10,6 +10,8 @@ import SamwaMoney.TimeTableArtist.Timetable.repository.TimetableRepository;
 import SamwaMoney.TimeTableArtist.Timetable.service.TimetableService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,8 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TableLikeService {
     private final MemberService memberService;
-    private final TimetableService timetableService;
     private final TableLikeRepository tableLikeRepository;
+    @Autowired
+    @Lazy
+    private TimetableService timetableService;
 
     // 좋아요 생성
     public void createTableLike(Long timetableId, Long memberId) {

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
@@ -51,6 +51,17 @@ public class TableLikeService {
         decrementLikeCount(timetable); // 좋아요 개수 감소
     }
 
+    // 사용자가 시간표를 좋아요했는지 확인
+    @Transactional(readOnly = true)
+    public boolean isTimetableLikedByMember(Long timetableId, Long memberId) {
+        if (memberId == null) {
+            return false;
+        }
+        Timetable timetable = timetableService.findTimetableById(timetableId);
+        Member member = memberService.findMemberById(memberId);
+        return tableLikeRepository.existsByOwnerAndTimetable(member, timetable);
+    }
+
     @Transactional(readOnly = true)
     public boolean isExistsByOwnerAndTimetable(Member owner, Timetable timetable) {
         return tableLikeRepository.existsByOwnerAndTimetable(owner, timetable);

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
@@ -37,6 +37,7 @@ public class TableLikeService {
                 .build();
 
         tableLikeRepository.save(tableLike);
+        incrementLikeCount(timetable); // 좋아요 개수 증가
     }
 
     // 좋아요 삭제
@@ -45,11 +46,30 @@ public class TableLikeService {
         Member owner = memberService.findMemberById(memberId);
         TableLike tableLike = tableLikeRepository.findByOwnerAndTimetable(owner, timetable)
                 .orElseThrow(() -> new RuntimeException("좋아요가 존재하지 않습니다."));
+
         tableLikeRepository.delete(tableLike);
+        decrementLikeCount(timetable); // 좋아요 개수 감소
     }
 
     @Transactional(readOnly = true)
     public boolean isExistsByOwnerAndTimetable(Member owner, Timetable timetable) {
         return tableLikeRepository.existsByOwnerAndTimetable(owner, timetable);
+    }
+
+    // 좋아요 추가시 좋아요 개수 증가
+    private void incrementLikeCount(Timetable timetable) {
+        timetable.setScore(timetable.getScore() + 1);
+    }
+
+    // 좋아요 삭제시 좋아요 개수 감소
+    private void decrementLikeCount(Timetable timetable) {
+        timetable.setScore(timetable.getScore() - 1);
+    }
+
+    // 좋아요 개수 조회
+    @Transactional(readOnly = true)
+    public long getLikeCount(Long timetableId) {
+        Timetable timetable = timetableService.findTimetableById(timetableId);
+        return timetable.getScore();
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/service/TableLikeService.java
@@ -73,18 +73,18 @@ public class TableLikeService {
 
     // 좋아요 추가시 좋아요 개수 증가
     private void incrementLikeCount(Timetable timetable) {
-        timetable.setScore(timetable.getScore() + 1);
+        timetable.setLikeCount(timetable.getLikeCount() + 1);
     }
 
     // 좋아요 삭제시 좋아요 개수 감소
     private void decrementLikeCount(Timetable timetable) {
-        timetable.setScore(timetable.getScore() - 1);
+        timetable.setLikeCount(timetable.getLikeCount() - 1);
     }
 
     // 좋아요 개수 조회
     @Transactional(readOnly = true)
     public long getLikeCount(Long timetableId) {
         Timetable timetable = timetableService.findTimetableById(timetableId);
-        return timetable.getScore();
+        return timetable.getLikeCount();
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
@@ -63,7 +63,7 @@ public class TimetableController {
     // 전체 시간표 조회 (사용자가 좋아요한 시간표 포함)
     @GetMapping("/board")
     @ResponseStatus(value = HttpStatus.OK)
-    public List<TimetableResponseWithLikeDto> getAllTimetablesWithLikeStatus(@RequestParam("sortType") boolean sortType, @RequestBody TimetableRankingRequestDto timetableRankingRequestDto) {
+    public List<TimetableResponseWithLikeDto> getAllTimetablesWithLikeStatus(@RequestParam("sortType") String sortType, @RequestBody TimetableRankingRequestDto timetableRankingRequestDto) {
         Long memberId = timetableRankingRequestDto.getMemberId();
         // 좋아요 여부 표시 전 전체 시간표 리스트
         List<TimetableResponseWithLikeDto> responseList = timetableService.getAllTimetablesWithLikeStatus(memberId);

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
@@ -1,24 +1,18 @@
 package SamwaMoney.TimeTableArtist.Timetable.controller;
 
-import SamwaMoney.TimeTableArtist.Class.domain.Class;
 import SamwaMoney.TimeTableArtist.Class.dto.ClassDto;
 import SamwaMoney.TimeTableArtist.Class.service.ClassService;
+import SamwaMoney.TimeTableArtist.TableLike.service.TableLikeService;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
-import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableFindResponseDto;
-import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableRequestDto;
-import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableResponseDto;
+import SamwaMoney.TimeTableArtist.Timetable.dto.*;
 import SamwaMoney.TimeTableArtist.Timetable.repository.TimetableRepository;
 import SamwaMoney.TimeTableArtist.Timetable.service.TimetableService;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.http.parser.Authorization;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +22,7 @@ public class TimetableController {
     private final TimetableService timetableService;
     private final TimetableRepository timetableRepository;
     private final ClassService classService;
+    private final TableLikeService tableLikeService;
 
     // 시간표 생성
     @PostMapping
@@ -51,5 +46,24 @@ public class TimetableController {
     public List<ClassDto> findClassListByTimetableId(@PathVariable("timetable_id") Long timetableId) {
         List<ClassDto> classDtoList = classService.findClassesByTimetableId(timetableId);
         return classDtoList;
+    }
+
+    // 전체 시간표 조회 (사용자가 좋아요한 시간표 포함)
+    @GetMapping("/board")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<TimetableResponseWithLikeDto> getAllTimetablesWithLikeStatus(@RequestParam("sortType") boolean sortType, @RequestBody TimetableRankingRequestDto timetableRankingRequestDto) {
+        Long memberId = timetableRankingRequestDto.getMemberId();
+        // 좋아요 여부 표시 전 전체 시간표 리스트
+        List<TimetableResponseWithLikeDto> responseList = timetableService.getAllTimetablesWithLikeStatus(memberId);
+        // 좋아요 여부 포함한 최종 시간표 리스트
+        List<TimetableResponseWithLikeDto> timetablesWithLikeStatus = new ArrayList<>();
+
+        for (TimetableResponseWithLikeDto timetableDto : responseList) {
+            boolean liked = tableLikeService.isTimetableLikedByMember(timetableDto.getTimetableId(), memberId);
+            timetableDto.setIsLiked(liked);
+            timetablesWithLikeStatus.add(timetableDto);
+        }
+
+        return timetablesWithLikeStatus;
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -53,6 +53,12 @@ public class Timetable extends BaseTimeEntity {
     @ColumnDefault("0")
     private Boolean classHide;
 
+    @Setter
+    private boolean isLiked;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "timetable")
+    private String timetableImg;
+
     @Builder
     public Timetable(Member owner, List<Class> classList, Long score, List<TablePlusComment> plusComments, List<TableMinusComment> minusComments,
                      List<TableSpecialComment> specialComments, Long ranking, Boolean classHide) {

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -3,6 +3,7 @@ package SamwaMoney.TimeTableArtist.Timetable.domain;
 import SamwaMoney.TimeTableArtist.Global.entity.BaseTimeEntity;
 import SamwaMoney.TimeTableArtist.Member.domain.Member;
 import SamwaMoney.TimeTableArtist.Class.domain.Class;
+import SamwaMoney.TimeTableArtist.TimetableImg.domain.TimetableImg;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableMinusComment;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TablePlusComment;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableSpecialComment;
@@ -56,8 +57,9 @@ public class Timetable extends BaseTimeEntity {
     @Setter
     private boolean isLiked;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "timetable")
-    private String timetableImg;
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "timetable_img_id")
+    private TimetableImg timetableImg;
 
     @Builder
     public Timetable(Member owner, List<Class> classList, Long score, List<TablePlusComment> plusComments, List<TableMinusComment> minusComments,

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -50,6 +50,12 @@ public class Timetable extends BaseTimeEntity {
     @ColumnDefault("0")
     private Boolean classHide;
 
+    @Setter
+    private boolean isLiked;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "timetable")
+    private String timetableImg;
+
     @Builder
     public Timetable(Member owner, List<Class> classList, Long score, List<TablePlusComment> plusComments, List<TableMinusComment> minusComments,
                      List<TableSpecialComment> specialComments, Long ranking, Boolean classHide) {

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -57,13 +57,25 @@ public class Timetable extends BaseTimeEntity {
     @Setter
     private boolean isLiked;
 
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    @Setter
+    private Long likeCount;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    @Setter
+    private Long replyCount;
+
+
+
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "timetable_img_id")
     private TimetableImg timetableImg;
 
     @Builder
     public Timetable(Member owner, List<Class> classList, Long score, List<TablePlusComment> plusComments, List<TableMinusComment> minusComments,
-                     List<TableSpecialComment> specialComments, Long ranking, Boolean classHide) {
+                     List<TableSpecialComment> specialComments, Long ranking, Boolean classHide, Long likeCount, long replyCount) {
         this.owner = owner;
         this.classList = classList;
         this.score = score;
@@ -72,5 +84,7 @@ public class Timetable extends BaseTimeEntity {
         this.specialComments = specialComments;
         this.ranking = ranking;
         this.classHide = classHide;
+        this.likeCount = likeCount;
+        this.replyCount = replyCount;
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -6,10 +6,7 @@ import SamwaMoney.TimeTableArtist.Class.domain.Class;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableMinusComment;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TablePlusComment;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableSpecialComment;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
@@ -35,6 +32,7 @@ public class Timetable extends BaseTimeEntity {
 
     @Column(nullable = false)
     @ColumnDefault("60")
+    @Setter
     private Long score;
 
     @OneToMany(mappedBy = "timetable")

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableRankingRequestDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableRankingRequestDto.java
@@ -1,0 +1,8 @@
+package SamwaMoney.TimeTableArtist.Timetable.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TimetableRankingRequestDto {
+    private Long memberId;
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableResponseWithLikeDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableResponseWithLikeDto.java
@@ -1,0 +1,48 @@
+package SamwaMoney.TimeTableArtist.Timetable.dto;
+
+import SamwaMoney.TimeTableArtist.Member.domain.Member;
+import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TimetableResponseWithLikeDto {
+    private Long timetableId;
+    private Member owner;
+    private Long ranking;
+    private Long score;
+    private String tableType;
+    private String tableImg;
+    private Long likeCount;
+    private Long replyCount;
+    private boolean isLiked;
+
+    public void setIsLiked(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+
+    public void setTableType(String tableType) {
+        this.tableType = tableType;
+    }
+
+    public void setTableImg(String tableImg) {
+        this.tableImg = tableImg;
+    }
+
+    // timetableDto에서 timetableId 받아오기
+    public static TimetableResponseWithLikeDto from(Timetable timetable, boolean isLiked, String tableType, String tableImg) {
+        TimetableResponseWithLikeDto dto = new TimetableResponseWithLikeDto();
+        dto.setTimetableId(timetable.getTimetableId());
+        dto.setOwner(timetable.getOwner());
+        dto.setRanking(timetable.getRanking());
+        dto.setScore(timetable.getScore());
+        dto.setLikeCount(timetable.getScore());
+//        dto.setReplyCount(timetable.getReplyCount());
+        dto.setTableImg(tableImg);
+        dto.setTableType(tableType);
+        dto.setIsLiked(isLiked);
+        return dto;
+    }
+
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableResponseWithLikeDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableResponseWithLikeDto.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 public class TimetableResponseWithLikeDto {
     private Long timetableId;
-    private Member owner;
+    private String ownerUsername;
     private Long ranking;
     private Long score;
     private String tableType;
@@ -34,7 +34,7 @@ public class TimetableResponseWithLikeDto {
     public static TimetableResponseWithLikeDto from(Timetable timetable, boolean isLiked, String tableType, String tableImg) {
         TimetableResponseWithLikeDto dto = new TimetableResponseWithLikeDto();
         dto.setTimetableId(timetable.getTimetableId());
-        dto.setOwner(timetable.getOwner());
+        dto.setOwnerUsername(timetable.getOwner().getUsername());
         dto.setRanking(timetable.getRanking());
         dto.setScore(timetable.getScore());
         dto.setLikeCount(timetable.getScore());

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableResponseWithLikeDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableResponseWithLikeDto.java
@@ -31,13 +31,13 @@ public class TimetableResponseWithLikeDto {
     }
 
     // timetableDto에서 timetableId 받아오기
-    public static TimetableResponseWithLikeDto from(Timetable timetable, boolean isLiked, String tableType, String tableImg) {
+    public static TimetableResponseWithLikeDto from(Timetable timetable, boolean isLiked, String tableType, String tableImg, Long likeCount) {
         TimetableResponseWithLikeDto dto = new TimetableResponseWithLikeDto();
         dto.setTimetableId(timetable.getTimetableId());
         dto.setOwnerUsername(timetable.getOwner().getUsername());
         dto.setRanking(timetable.getRanking());
         dto.setScore(timetable.getScore());
-        dto.setLikeCount(timetable.getScore());
+        dto.setLikeCount(likeCount);
 //        dto.setReplyCount(timetable.getReplyCount());
         dto.setTableImg(tableImg);
         dto.setTableType(tableType);

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -3,13 +3,17 @@ package SamwaMoney.TimeTableArtist.Timetable.service;
 import SamwaMoney.TimeTableArtist.Member.domain.Member;
 import SamwaMoney.TimeTableArtist.Member.repository.MemberRepository;
 import SamwaMoney.TimeTableArtist.Member.service.MemberService;
+import SamwaMoney.TimeTableArtist.TableLike.service.TableLikeService;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableRequestDto;
+import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableResponseWithLikeDto;
 import SamwaMoney.TimeTableArtist.Timetable.repository.TimetableRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -18,8 +22,7 @@ public class TimetableService {
 
     private final TimetableRepository timetableRepository;
     private final MemberRepository memberRepository;
-
-    private final MemberService memberService;
+    private final TableLikeService tableLikeService;
 
     // 시간표 생성
     public Timetable createTimetable(TimetableRequestDto requestDto) {
@@ -46,5 +49,21 @@ public class TimetableService {
     public Timetable findTimetableById(Long timetableId){
         return timetableRepository.findById(timetableId)
                 .orElseThrow(()->new EntityNotFoundException("해당 시간표가 존재하지 않습니다."));
+    }
+
+    // 전체 시간표 조회 (사용자가 좋아요한 시간표 포함)
+    @Transactional(readOnly = true)
+    public List<TimetableResponseWithLikeDto> getAllTimetablesWithLikeStatus(Long memberId) {
+        List<Timetable> allTimetables = timetableRepository.findAll();
+
+        List<TimetableResponseWithLikeDto> responseList = new ArrayList<>();
+        for (Timetable timetable : allTimetables) {
+            boolean isLiked = tableLikeService.isTimetableLikedByMember(timetable.getTimetableId(), memberId);
+            String tableType = "";
+            String tableImg = "";
+            responseList.add(TimetableResponseWithLikeDto.from(timetable, isLiked, tableType, tableImg));
+        }
+
+        return responseList;
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -79,9 +79,10 @@ public class TimetableService {
         List<TimetableResponseWithLikeDto> responseList = new ArrayList<>();
         for (Timetable timetable : allTimetables) {
             boolean isLiked = tableLikeService.isTimetableLikedByMember(timetable.getTimetableId(), memberId);
+            long likeCount = tableLikeService.getLikeCount(timetable.getTimetableId());
             String tableType = "";
             String tableImg = "";
-            responseList.add(TimetableResponseWithLikeDto.from(timetable, isLiked, tableType, tableImg));
+            responseList.add(TimetableResponseWithLikeDto.from(timetable, isLiked, tableType, tableImg, likeCount));
         }
 
         return responseList;

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TimetableImg/domain/TimetableImg.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TimetableImg/domain/TimetableImg.java
@@ -1,0 +1,34 @@
+package SamwaMoney.TimeTableArtist.TimetableImg.domain;
+
+import SamwaMoney.TimeTableArtist.Global.entity.BaseTimeEntity;
+import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TimetableImg extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "timetable_img_id", nullable = false, updatable = false)
+    private Long timetableImgId;
+
+    // 이미지 URL을 저장할 필드
+    private String imageUrl;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "timetable_id", nullable = false, updatable = false)
+    private Timetable timetable;
+
+    @Builder
+    public TimetableImg(String imageUrl, Timetable timetable) {
+        this.imageUrl = imageUrl;
+        this.timetable = timetable;
+    }
+}


### PR DESCRIPTION
# 구현 기능
- 좋아요 등록/취소 누를 때마다 개수 더하기/빼기
- 전체 시간표를 조회할 때 시간표 좋아요 개수 속성/유저별 시간표 좋아요 여부를 포함하여 반환하기

# 구현 상태
<img width="1392" alt="스크린샷 2023-07-24 오후 3 55 16" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/77741296/4beddbba-22c1-4f45-8aec-79e1c6216467">
member가 좋아요한 시간표에만 `isLiked==true` 값을 반환합니다.

<img width="1392" alt="스크린샷 2023-07-24 오후 3 55 24" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/77741296/b48c2f1a-9710-4e85-8b40-da7aef114c88">
memberId==null일 때 모든 isLiked에 대해 false 값을 반환합니다

<img width="1392" alt="스크린샷 2023-07-24 오후 4 22 02" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/77741296/ceb66467-2b60-4124-a29f-b8ccf2407efe">
좋아요 개수가 올바르게 적용된 모습입니다.

**참조사항**
전체 랭킹보드 GET 처리해주시는 분이 `tableType`, `replyCount`, `timetableImg`까지 조회할 수 있도록 구현해주시면 됩니다! `tableImg`의 경우 랭킹보드 등록 api 구현 기능이 완료되어야만 가져올 수 있을 것 같아요.