### PR TITLE
[조민서] 랭킹보드 조회 구현, 내 시간표 조회 수정

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
@@ -94,11 +94,8 @@ public class TimetableController {
     // 랭킹보드 조회
     @GetMapping("/rankingboard")
     @ResponseStatus(value = HttpStatus.OK)
-    public List<RankingboardGetResponseDto> getRankingboard(@RequestParam("sortType") String sortType, @RequestBody TimetableRankingRequestDto timetableRankingRequestDto) {
-        Long memberId = timetableRankingRequestDto.getMemberId();
-
-        List<RankingboardGetResponseDto> rankingboard = timetableService.getRankingboardTimetables(memberId, sortType);
-
+    public List<RankingboardGetResponseDto> getRankingboard(@RequestParam("sortType") String sortType) {
+        List<RankingboardGetResponseDto> rankingboard = timetableService.getRankingboardTimetables(sortType);
         return rankingboard;
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
@@ -94,8 +94,10 @@ public class TimetableController {
     // 랭킹보드 조회
     @GetMapping("/rankingboard")
     @ResponseStatus(value = HttpStatus.OK)
-    public List<RankingboardGetResponseDto> getRankingboard(@RequestParam("sortType") String sortType) {
-        List<RankingboardGetResponseDto> rankingboard = timetableService.getRankingboardTimetables(sortType);
+    public List<RankingboardGetResponseDto> getRankingboard(@RequestParam("sortType") String sortType, @RequestBody TimetableRankingRequestDto timetableRankingRequestDto) {
+        Long memberId = timetableRankingRequestDto.getMemberId();
+
+        List<RankingboardGetResponseDto> rankingboard = timetableService.getRankingboardTimetables(sortType, memberId);
         return rankingboard;
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
@@ -1,12 +1,10 @@
 package SamwaMoney.TimeTableArtist.Timetable.controller;
 
-import SamwaMoney.TimeTableArtist.Class.dto.ClassDto;
 import SamwaMoney.TimeTableArtist.Class.service.ClassService;
 import SamwaMoney.TimeTableArtist.Global.service.S3Uploader;
 import SamwaMoney.TimeTableArtist.TableLike.service.TableLikeService;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import SamwaMoney.TimeTableArtist.Timetable.dto.*;
-import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableFindResponseDto;
 import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableFullResponseDto;
 import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableRequestDto;
 import SamwaMoney.TimeTableArtist.Timetable.dto.TimetableResponseDto;
@@ -91,5 +89,16 @@ public class TimetableController {
         String tableTypeContent = timetableService.readTableTypeContent(timetableId);
         RankingResponseDto rankingResponseDto = timetableService.updateByRankingReqDto(timetableId, rankingReqDto, fileUrl);
         return ResponseEntity.ok(rankingResponseDto);
+    }
+
+    // 랭킹보드 조회
+    @GetMapping("/rankingboard")
+    @ResponseStatus(value = HttpStatus.OK)
+    public List<RankingboardGetResponseDto> getRankingboard(@RequestParam("sortType") String sortType, @RequestBody TimetableRankingRequestDto timetableRankingRequestDto) {
+        Long memberId = timetableRankingRequestDto.getMemberId();
+
+        List<RankingboardGetResponseDto> rankingboard = timetableService.getRankingboardTimetables(memberId, sortType);
+
+        return rankingboard;
     }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -101,6 +101,8 @@ public class Timetable extends BaseTimeEntity {
         this.specialComments = new ArrayList<>();
         this.ranking = false;
         this.classHide = false;
+        this.likeCount = 0L;
+        this.replyCount = 0L;
     }
 
     // 랭킹보드 게시

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -3,6 +3,7 @@ package SamwaMoney.TimeTableArtist.Timetable.domain;
 import SamwaMoney.TimeTableArtist.Global.entity.BaseTimeEntity;
 import SamwaMoney.TimeTableArtist.Member.domain.Member;
 import SamwaMoney.TimeTableArtist.Class.domain.Class;
+import SamwaMoney.TimeTableArtist.TableLike.service.TableLikeService;
 import SamwaMoney.TimeTableArtist.Timetable.dto.RankingRequestDto;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableMinusComment;
 import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TablePlusComment;
@@ -76,7 +77,7 @@ public class Timetable extends BaseTimeEntity {
 
     @Builder
     public Timetable(Member owner, List<Class> classList, Long score, List<TablePlusComment> plusComments, List<TableMinusComment> minusComments,
-                     List<TableSpecialComment> specialComments, boolean ranking, boolean classHide, String imgUrl, Long likeCount, long replyCount, String tableTypeContent) {
+                     List<TableSpecialComment> specialComments, boolean ranking, boolean classHide, String imgUrl, boolean isLiked, Long likeCount, long replyCount, String tableTypeContent) {
         this.owner = owner;
         this.classList = classList;
         this.score = score;
@@ -86,6 +87,7 @@ public class Timetable extends BaseTimeEntity {
         this.ranking = ranking;
         this.classHide = classHide;
         this.imgUrl = imgUrl;
+        this.isLiked = isLiked;
         this.likeCount = likeCount;
         this.replyCount = replyCount;
         this.tableTypeContent = tableTypeContent;

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/RankingboardGetResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/RankingboardGetResponseDto.java
@@ -1,0 +1,83 @@
+package SamwaMoney.TimeTableArtist.Timetable.dto;
+
+import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingboardGetResponseDto {
+    private Long timetableId;
+    private String username;
+    private Long score;
+    private boolean ranking;
+    private boolean classHide;
+    private String imgUrl;
+    private String tableTypeContent;
+    private Long likeCount;
+    private Long replyCount;
+    private boolean isLiked;
+
+    public RankingboardGetResponseDto() {
+
+    }
+
+    public void setIsLiked(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+
+    public static RankingboardGetResponseDto from(Timetable timetable, boolean isLiked) {
+        RankingboardGetResponseDto dto = new RankingboardGetResponseDto();
+        dto.setTimetableId(timetable.getTimetableId());
+        dto.setUsername(timetable.getOwner().getUsername());
+        dto.setScore(timetable.getScore());
+        dto.setRanking(timetable.isRanking());
+        dto.setClassHide(timetable.isClassHide());
+        dto.setImgUrl(timetable.getImgUrl());
+        dto.setTableTypeContent(timetable.getTableTypeContent());
+        dto.setLikeCount(timetable.getLikeCount());
+        dto.setReplyCount(timetable.getReplyCount());
+        dto.setIsLiked(isLiked);
+        return dto;
+    }
+
+
+//    private List<RankingboardList> rankingboardList;
+//
+//    public static RankingboardGetResponseDto of(List<Timetable> timetableList) {
+//        return RankingboardGetResponseDto.builder()
+//                .rankingboardList(timetableList.stream().map(RankingboardList::of).collect(Collectors.toList()))
+//                .build();
+//    }
+//
+//    public static class RankingboardList {
+//        private Long timetableId;
+//        private String username;
+//        private Long score;
+//        private boolean ranking;
+//        private boolean classHide;
+//        private String imgUrl;
+//        private String tableTypeContent;
+//        private Long likeCount;
+//        private Long replyCount;
+//        private boolean isLiked;
+//
+//        public RankingboardList(Timetable timetable) {
+//            this.timetableId = timetable.getTimetableId();
+//            this.username = timetable.getOwner().getUsername();
+//            this.score = timetable.getScore();
+//            this.ranking = timetable.isRanking();
+//            this.classHide = timetable.isClassHide();
+//            this.imgUrl = timetable.getImgUrl();
+//            this.tableTypeContent = timetable.getTableTypeContent();
+//            this.likeCount = timetable.getLikeCount();
+//            this.replyCount = timetable.getReplyCount();
+//            this.isLiked = timetable.isLiked();
+//        }
+//
+//        public static RankingboardList of(Timetable timetable) {
+//            return new RankingboardList(timetable);
+//        }
+//    }
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/RankingboardGetResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/RankingboardGetResponseDto.java
@@ -27,7 +27,7 @@ public class RankingboardGetResponseDto {
         this.isLiked = isLiked;
     }
 
-    public static RankingboardGetResponseDto from(Timetable timetable, boolean isLiked) {
+    public static RankingboardGetResponseDto from(Timetable timetable) {
         RankingboardGetResponseDto dto = new RankingboardGetResponseDto();
         dto.setTimetableId(timetable.getTimetableId());
         dto.setUsername(timetable.getOwner().getUsername());
@@ -38,7 +38,7 @@ public class RankingboardGetResponseDto {
         dto.setTableTypeContent(timetable.getTableTypeContent());
         dto.setLikeCount(timetable.getLikeCount());
         dto.setReplyCount(timetable.getReplyCount());
-        dto.setIsLiked(isLiked);
+        dto.setIsLiked(timetable.isLiked());
         return dto;
     }
 

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/RankingboardGetResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/RankingboardGetResponseDto.java
@@ -23,11 +23,15 @@ public class RankingboardGetResponseDto {
 
     }
 
+    public void setLikeCount(Long likeCount) {
+        this.likeCount = likeCount;
+    }
+
     public void setIsLiked(boolean isLiked) {
         this.isLiked = isLiked;
     }
 
-    public static RankingboardGetResponseDto from(Timetable timetable) {
+    public static RankingboardGetResponseDto from(Timetable timetable, Long likeCount, boolean isLiked) {
         RankingboardGetResponseDto dto = new RankingboardGetResponseDto();
         dto.setTimetableId(timetable.getTimetableId());
         dto.setUsername(timetable.getOwner().getUsername());
@@ -36,48 +40,9 @@ public class RankingboardGetResponseDto {
         dto.setClassHide(timetable.isClassHide());
         dto.setImgUrl(timetable.getImgUrl());
         dto.setTableTypeContent(timetable.getTableTypeContent());
-        dto.setLikeCount(timetable.getLikeCount());
+        dto.setLikeCount(likeCount);
         dto.setReplyCount(timetable.getReplyCount());
-        dto.setIsLiked(timetable.isLiked());
+        dto.setIsLiked(isLiked);
         return dto;
     }
-
-
-//    private List<RankingboardList> rankingboardList;
-//
-//    public static RankingboardGetResponseDto of(List<Timetable> timetableList) {
-//        return RankingboardGetResponseDto.builder()
-//                .rankingboardList(timetableList.stream().map(RankingboardList::of).collect(Collectors.toList()))
-//                .build();
-//    }
-//
-//    public static class RankingboardList {
-//        private Long timetableId;
-//        private String username;
-//        private Long score;
-//        private boolean ranking;
-//        private boolean classHide;
-//        private String imgUrl;
-//        private String tableTypeContent;
-//        private Long likeCount;
-//        private Long replyCount;
-//        private boolean isLiked;
-//
-//        public RankingboardList(Timetable timetable) {
-//            this.timetableId = timetable.getTimetableId();
-//            this.username = timetable.getOwner().getUsername();
-//            this.score = timetable.getScore();
-//            this.ranking = timetable.isRanking();
-//            this.classHide = timetable.isClassHide();
-//            this.imgUrl = timetable.getImgUrl();
-//            this.tableTypeContent = timetable.getTableTypeContent();
-//            this.likeCount = timetable.getLikeCount();
-//            this.replyCount = timetable.getReplyCount();
-//            this.isLiked = timetable.isLiked();
-//        }
-//
-//        public static RankingboardList of(Timetable timetable) {
-//            return new RankingboardList(timetable);
-//        }
-//    }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
@@ -19,6 +19,7 @@ public class TimetableFullResponseDto {
     private Long timetableId;
     private String owner;
     private Long likeCount;
+    private boolean isLiked;
     private LocalDateTime createdAt;
 
     private List<ClassDto> classList;
@@ -26,11 +27,12 @@ public class TimetableFullResponseDto {
 
 
     @Builder
-    public TimetableFullResponseDto(Long memberId, Long timetableId, String owner, Long likeCount, LocalDateTime createdAt, List<ClassDto> classList) {
+    public TimetableFullResponseDto(Long memberId, Long timetableId, String owner, Long likeCount, boolean isLiked, LocalDateTime createdAt, List<ClassDto> classList) {
         this.memberId = memberId;
         this.timetableId = timetableId;
         this.owner = owner;
         this.likeCount = likeCount;
+        this.isLiked = isLiked;
         this.createdAt = createdAt;
         this.classList = classList;
     }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
@@ -17,14 +17,20 @@ public class TimetableFullResponseDto {
 
     private Long memberId;
     private Long timetableId;
+    private String owner;
+    private Long likeCount;
     private LocalDateTime createdAt;
 
     private List<ClassDto> classList;
 
+
+
     @Builder
-    public TimetableFullResponseDto(Long memberId, Long timetableId, LocalDateTime createdAt, List<ClassDto> classList) {
+    public TimetableFullResponseDto(Long memberId, Long timetableId, String owner, Long likeCount, LocalDateTime createdAt, List<ClassDto> classList) {
         this.memberId = memberId;
         this.timetableId = timetableId;
+        this.owner = owner;
+        this.likeCount = likeCount;
         this.createdAt = createdAt;
         this.classList = classList;
     }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/repository/TimetableRepository.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/repository/TimetableRepository.java
@@ -1,7 +1,6 @@
 package SamwaMoney.TimeTableArtist.Timetable.repository;
 
 import SamwaMoney.TimeTableArtist.Class.domain.Class;
-import SamwaMoney.TimeTableArtist.Member.domain.Member;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -16,4 +15,5 @@ public interface TimetableRepository extends JpaRepository<Timetable, Long> {
     List<Class> findAllByTimetableId(Long timetableId);
     Optional<Timetable> findById(Long timetableId);
     Timetable findByTimetableId (Long timetableId);
+
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -11,6 +11,7 @@ import SamwaMoney.TimeTableArtist.Comment.entity.SpecialComment;
 import SamwaMoney.TimeTableArtist.Comment.repository.SpecialCommentRepository;
 import SamwaMoney.TimeTableArtist.Member.domain.Member;
 import SamwaMoney.TimeTableArtist.Member.repository.MemberRepository;
+import SamwaMoney.TimeTableArtist.TableLike.domain.TableLike;
 import SamwaMoney.TimeTableArtist.TableLike.service.TableLikeService;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import SamwaMoney.TimeTableArtist.Timetable.dto.*;
@@ -172,10 +173,12 @@ public class TimetableService {
                 .map(ClassDto::from)
                 .collect(Collectors.toList());
     }
+
     // 내 시간표 조회에 사용
     public TimetableFullResponseDto showTimetable(Long timetableId) {
         // timetableId를 기준으로 Timetable 하나 찾아오기
         Timetable timetable = findTimetableById(timetableId);
+
 
         // timetableId를 기준으로, 이 시간표에 속한 모든 수업들의 정보를 담은 DTO 리스트 받아오기
         List<ClassDto> classList = classService.findClassesByTimetableId(timetableId);
@@ -184,6 +187,8 @@ public class TimetableService {
         return TimetableFullResponseDto.builder()
                 .memberId(timetable.getOwner().getMemberId())
                 .timetableId(timetable.getTimetableId())
+                .owner(timetable.getOwner().getUsername())
+                .likeCount(timetable.getLikeCount())
                 .createdAt(timetable.getCreatedAt())
                 .classList(classList)
                 .build();

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -212,7 +212,7 @@ public class TimetableService {
 
     // 랭킹보드 조회
     @Transactional(readOnly = true)
-    public List<RankingboardGetResponseDto> getRankingboardTimetables(String sortType) {
+    public List<RankingboardGetResponseDto> getRankingboardTimetables(String sortType, Long memberId) {
         List<Timetable> allTimetables = timetableRepository.findAll(Sort.by(Sort.Direction.DESC, "score"));
 
         if (sortType.equals("LOWEST")) {
@@ -223,7 +223,14 @@ public class TimetableService {
 
         List<RankingboardGetResponseDto> responseList = new ArrayList<>();
         for (Timetable timetable : allTimetables) {
-            responseList.add(RankingboardGetResponseDto.from(timetable));
+            long likeCount = tableLikeService.getLikeCount(timetable.getTimetableId());
+            boolean isLiked = false;
+
+            if (memberId != null) {
+                isLiked = tableLikeService.isTimetableLikedByMember(timetable.getTimetableId(), memberId);
+            }
+
+            responseList.add(RankingboardGetResponseDto.from(timetable, likeCount, isLiked));
         }
 
         return responseList;

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -179,6 +179,8 @@ public class TimetableService {
         // timetableId를 기준으로 Timetable 하나 찾아오기
         Timetable timetable = findTimetableById(timetableId);
 
+        // timetableId와 memberId를 기준으로 본인의 내 시간표 좋아요 여부 찾아오기
+        boolean isLiked = tableLikeService.isTimetableLikedByMember(timetableId, timetable.getOwner().getMemberId());
 
         // timetableId를 기준으로, 이 시간표에 속한 모든 수업들의 정보를 담은 DTO 리스트 받아오기
         List<ClassDto> classList = classService.findClassesByTimetableId(timetableId);
@@ -189,6 +191,7 @@ public class TimetableService {
                 .timetableId(timetable.getTimetableId())
                 .owner(timetable.getOwner().getUsername())
                 .likeCount(timetable.getLikeCount())
+                .isLiked(isLiked)
                 .createdAt(timetable.getCreatedAt())
                 .classList(classList)
                 .build();

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -212,7 +212,7 @@ public class TimetableService {
 
     // 랭킹보드 조회
     @Transactional(readOnly = true)
-    public List<RankingboardGetResponseDto> getRankingboardTimetables(Long memberId, String sortType) {
+    public List<RankingboardGetResponseDto> getRankingboardTimetables(String sortType) {
         List<Timetable> allTimetables = timetableRepository.findAll(Sort.by(Sort.Direction.DESC, "score"));
 
         if (sortType.equals("LOWEST")) {
@@ -223,9 +223,7 @@ public class TimetableService {
 
         List<RankingboardGetResponseDto> responseList = new ArrayList<>();
         for (Timetable timetable : allTimetables) {
-            boolean isLiked = tableLikeService.isTimetableLikedByMember(timetable.getTimetableId(), memberId);
-            long likeCount = tableLikeService.getLikeCount(timetable.getTimetableId());
-            responseList.add(RankingboardGetResponseDto.from(timetable, isLiked));
+            responseList.add(RankingboardGetResponseDto.from(timetable));
         }
 
         return responseList;

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/tablecommentmap/domain/TableMinusComment.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/tablecommentmap/domain/TableMinusComment.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/tablecommentmap/domain/TablePlusComment.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/tablecommentmap/domain/TablePlusComment.java
@@ -12,7 +12,6 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TablePlusComment {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "table_pluscomment_id", nullable = false, updatable = false)

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/utils/TimetableUtil.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/utils/TimetableUtil.java
@@ -14,31 +14,112 @@ public class TimetableUtil {
     public static Map<List<String>, MoveDto> makeMoveDifficulties () {
         Map<List<String>, MoveDto> moveDifficulty = new HashMap<>();
 
-        //  - data1~data6을 채점하기 위한 이동난이도 쌍
-        moveDifficulty.put(Arrays.asList("학관", "학관"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("학관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("학관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        // ECC
         moveDifficulty.put(Arrays.asList("ECC", "학관"), new MoveDto(true, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("공학관", "학관"), new MoveDto(false, Difficulty.HIGH));
-        //  - data7(삼와머니 팀원들이 모은 시간표)을 채점하기 위한 이동난이도 쌍
         moveDifficulty.put(Arrays.asList("ECC", "ECC"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("공학관", "공학관"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("신세계관", "신세계관"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("조형예술관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("종합과학관", "종합과학관"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("포스코관", "포스코관"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("ECC", "대강당"), new MoveDto(true, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("ECC", "신세계관"), new MoveDto(true, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("ECC", "조형예술관"), new MoveDto(true, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("ECC", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("ECC", "포스코관"), new MoveDto(true, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("ECC", "학관"), new MoveDto(true, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "공학관"), new MoveDto(true, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "대강당"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "교육관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "국제교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("ECC", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("ECC", "생활관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("ECC", "약학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "sk텔레콤관(정보관)"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("ECC", "체육관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("ECC", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 공학관
         moveDifficulty.put(Arrays.asList("공학관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("공학관", "대강당"), new MoveDto(false, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("공학관", "종합과학관"), new MoveDto(false, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("공학관", "포스코관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "공학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("공학관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "ECC"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("공학관", "국제교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "법학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "헬렌관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "생활관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "약학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "조형예술관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "체육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("공학관", "음악관"), new MoveDto(false, Difficulty.HIGH));
+
+        // 교육관
+        moveDifficulty.put(Arrays.asList("교육관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "대강당"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("교육관", "포스코관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("교육관", "공학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("교육관", "ECC"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("교육관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("교육관", "헬렌관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("교육관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("교육관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("교육관", "생활관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("교육관", "약학관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("교육관", "신세계관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "조형예술관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("교육관", "체육관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("교육관", "음악관"), new MoveDto(true, Difficulty.HIGH));
+
+        // 학관
+        moveDifficulty.put(Arrays.asList("학관", "학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "대강당"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "포스코관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "헬렌관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("학관", "생활관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "약학관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "신세계관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("학관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "조형예술관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "체육관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("학관", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 국제교육관
+        moveDifficulty.put(Arrays.asList("국제교육관", "학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "ECC"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("국제교육관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("국제교육관", "대강당"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("국제교육관", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "포스코관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "국제교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("국제교육관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("국제교육관", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("국제교육관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("국제교육관", "생활관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("국제교육관", "약학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "신세계관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("국제교육관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("국제교육관", "조형예술관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "체육관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("국제교육관", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 대강당
         moveDifficulty.put(Arrays.asList("대강당", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("대강당", "ECC"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("대강당", "공학관"), new MoveDto(true, Difficulty.HIGH));
@@ -47,28 +128,290 @@ public class TimetableUtil {
         moveDifficulty.put(Arrays.asList("대강당", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("대강당", "포스코관"), new MoveDto(true, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("대강당", "학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "국제교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "대강당"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "법학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("대강당", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("대강당", "연구협력관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "테니스장"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "생활관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "약학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("대강당", "체육관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("대강당", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 법학관
+        moveDifficulty.put(Arrays.asList("법학관", "sk텔레콤관(정보관)"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("법학관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("법학관", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "포스코관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("법학관", "학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "교육관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "국제교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "대강당"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "법학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("법학관", "헬렌관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("법학관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "생활관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("법학관", "약학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("법학관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("법학관", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 헬렌관
+        moveDifficulty.put(Arrays.asList("헬렌관", "ECC"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("헬렌관", "공학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "교육관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("헬렌관", "학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "대강당"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "법학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "헬렌관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("헬렌관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("헬렌관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("헬렌관", "생활관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "약학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("헬렌관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("헬렌관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("헬렌관", "체육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("헬렌관", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("헬렌관", "포스코관"), new MoveDto(false, Difficulty.LOW));
+
+        // 연구협력관
+        moveDifficulty.put(Arrays.asList("연구협력관", "ECC"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "공학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "국제교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "대강당"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "법학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "헬렌관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "연구협력관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("연구협력관", "테니스장"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("연구협력관", "생활관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "약학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "조형예술관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "체육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "음악관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "종합과학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("연구협력관", "포스코관"), new MoveDto(false, Difficulty.HIGH));
+
+        // 테니스장
+        moveDifficulty.put(Arrays.asList("테니스장", "ECC"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "공학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "국제교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "대강당"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "법학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("테니스장", "헬렌관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "연구협력관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("테니스장", "테니스장"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("테니스장", "생활관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "약학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "조형예술관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "체육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "음악관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "종합과학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("테니스장", "포스코관"), new MoveDto(false, Difficulty.HIGH));
+
+        // 생활관
+        moveDifficulty.put(Arrays.asList("생활관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("생활관", "교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "대강당"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("생활관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("생활관", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("생활관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("생활관", "생활관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("생활관", "약학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("생활관", "신세계관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("생활관", "조형예술관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "음악관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("생활관", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("생활관", "포스코관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 약학관
+        moveDifficulty.put(Arrays.asList("약학관", "ECC"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("약학관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("약학관", "교육관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("약학관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("약학관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "대강당"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("약학관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("약학관", "헬렌관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("약학관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("약학관", "생활관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("약학관", "약학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("약학관", "신세계관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "조형예술관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("약학관", "포스코관"), new MoveDto(true, Difficulty.LOW));
+
+        // 신세계관
         moveDifficulty.put(Arrays.asList("신세계관", "ECC"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("신세계관", "대강당"), new MoveDto(true, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("신세계관", "포스코관"), new MoveDto(true, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("신세계관", "조형예술관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("신세계관", "국제교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("신세계관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "생활관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "약학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("신세계관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("신세계관", "음악관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("신세계관", "신세계관"), new MoveDto(false, Difficulty.LOW));
+
+        // sk텔레콤관(정보관)
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "대강당"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "ECC"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "포스코관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "조형예술관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "국제교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "생활관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "약학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "신세계관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "음악관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("sk텔레콤관(정보관)", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+
+        // 조형예술관
         moveDifficulty.put(Arrays.asList("조형예술관", "ECC"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("조형예술관", "대강당"), new MoveDto(false, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("조형예술관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "대강당"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "법학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "헬렌관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "생활관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "약학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "신세계관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("조형예술관", "음악관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("조형예술관", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("조형예술관", "포스코관"), new MoveDto(true, Difficulty.LOW));
+
+        // 체육관
+        moveDifficulty.put(Arrays.asList("체육관", "ECC"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("체육관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "국제교육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("체육관", "대강당"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "법학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "헬렌관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "생활관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "약학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "신세계관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("체육관", "체육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("체육관", "음악관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("체육관", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("체육관", "포스코관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 음악관
+        moveDifficulty.put(Arrays.asList("음악관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("음악관", "공학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "국제교육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("음악관", "대강당"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("음악관", "법학관"), new MoveDto(true, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("음악관", "헬렌관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("음악관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "생활관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("음악관", "약학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("음악관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("음악관", "체육관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("음악관", "음악관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("음악관", "종합과학관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("음악관", "포스코관"), new MoveDto(true, Difficulty.MEDIUM));
+
+        // 종합과학관
         moveDifficulty.put(Arrays.asList("종합과학관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("종합과학관", "공학관"), new MoveDto(false, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("종합과학관", "대강당"), new MoveDto(false, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("종합과학관", "포스코관"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("종합과학관", "학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "조형예술관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "종합과학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("종합과학관", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "국제교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "법학관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "헬렌관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "생활관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "약학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("종합과학관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("종합과학관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("종합과학관", "음악관"), new MoveDto(false, Difficulty.HIGH));
+
+        // 포스코관
+        moveDifficulty.put(Arrays.asList("포스코관", "포스코관"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("포스코관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
         moveDifficulty.put(Arrays.asList("포스코관", "공학관"), new MoveDto(true, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("포스코관", "대강당"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("포스코관", "신세계관"), new MoveDto(false, Difficulty.HIGH));
         moveDifficulty.put(Arrays.asList("포스코관", "종합과학관"), new MoveDto(false, Difficulty.LOW));
         moveDifficulty.put(Arrays.asList("포스코관", "학관"), new MoveDto(false, Difficulty.HIGH));
-        moveDifficulty.put(Arrays.asList("학관", "ECC"), new MoveDto(false, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("학관", "대강당"), new MoveDto(false, Difficulty.LOW));
-        moveDifficulty.put(Arrays.asList("학관", "종합과학관"), new MoveDto(true, Difficulty.MEDIUM));
-        moveDifficulty.put(Arrays.asList("학관", "포스코관"), new MoveDto(true, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "국제교육관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "법학관"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "헬렌관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "연구협력관"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "테니스장"), new MoveDto(true, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "생활관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "약학관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "sk텔레콤관(정보관)"), new MoveDto(false, Difficulty.HIGH));
+        moveDifficulty.put(Arrays.asList("포스코관", "조형예술관"), new MoveDto(false, Difficulty.LOW));
+        moveDifficulty.put(Arrays.asList("포스코관", "체육관"), new MoveDto(false, Difficulty.MEDIUM));
+        moveDifficulty.put(Arrays.asList("포스코관", "음악관"), new MoveDto(false, Difficulty.MEDIUM));
 
         // 완성된 이동난이도 Map을 리턴
         return moveDifficulty;


### PR DESCRIPTION
# 구현 기능
- 랭킹보드 조회 기능 (최고의 시간표, 최악의 시간표, 인기 시간표)
- 내 시간표 조회 기능 owner, likeCount 추가

# 구현 상태
- 알고리즘 이동 난이도 코드 추가
- 기능 구현하면서 랭킹보드 조회 API 문서에서 달라진 부분 수정했습니다.
- 포스트맨 테스트 완료 
[랭킹보드 조회] https://painted-catboat-bae.notion.site/6a05b6df43cb47a6b26db08aa9167aae?pvs=4
[내 시간표 조회] https://painted-catboat-bae.notion.site/0a2c51d73ad04dc1b12fd26cd9fa5c50?pvs=4
