### PR TITLE
[노하은] 내 시간표 조회 응답형식 변경

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Comment/dto/CommentResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Comment/dto/CommentResponseDto.java
@@ -1,0 +1,33 @@
+package SamwaMoney.TimeTableArtist.Comment.dto;
+
+import SamwaMoney.TimeTableArtist.Comment.entity.MinusComment;
+import SamwaMoney.TimeTableArtist.Comment.entity.PlusComment;
+import SamwaMoney.TimeTableArtist.Comment.entity.SpecialComment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentResponseDto {
+    private String commentType; // 해당 코멘트가 plus, minus, special 중 어느 것인지 명시
+    private Long commentId;     // 코멘트의 ID
+    private String content;      // 코멘트 내용
+
+    // 세 가지 코멘트에 대한 생성자
+    public CommentResponseDto (PlusComment comment) {
+        this.commentType = "plus";
+        this.commentId = comment.getPlusCommentId();
+        this.content = comment.getContent();
+    }
+    public CommentResponseDto (MinusComment comment) {
+        this.commentType = "minus";
+        this.commentId = comment.getMinusCommentId();
+        this.content = comment.getContent();
+    }
+    public CommentResponseDto (SpecialComment comment) {
+        this.commentType = "special";
+        this.commentId = comment.getSpecialCommentId();
+        this.content = comment.getContent();
+    }
+}

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
@@ -1,7 +1,7 @@
 package SamwaMoney.TimeTableArtist.Timetable.dto;
 
 import SamwaMoney.TimeTableArtist.Class.dto.ClassDto;
-import SamwaMoney.TimeTableArtist.Class.domain.Class;
+import SamwaMoney.TimeTableArtist.Comment.dto.CommentResponseDto;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,18 +15,37 @@ import java.util.List;
 @NoArgsConstructor
 public class TimetableFullResponseDto {
 
-    private Long memberId;
-    private Long timetableId;
-    private LocalDateTime createdAt;
+    private Long memberId;  // 작성자 ID
+    private Long timetableId;   // 시간표 ID
+    private Long score;      // 점수
+    private Long tableType;     // 시간표 유형의 ID (해당되는 스페셜 코멘트의 ID)
+    private String tableTypeContent;    // 시간표 유형 내용
+    private Boolean classHide;  // 수업명 숨기기 여부
+    private String photo;       // 시간표의 유형에 해당하는 짤의 ImgURL
+    private LocalDateTime createdAt;    // 작성일시
+    private List<ClassDto> classList;   // 수업 목록
+    private List<CommentResponseDto> plusComments;
+    private List<CommentResponseDto> minusComments;
+    private List<CommentResponseDto> specialComments;
 
-    private List<ClassDto> classList;
 
     @Builder
-    public TimetableFullResponseDto(Long memberId, Long timetableId, LocalDateTime createdAt, List<ClassDto> classList) {
-        this.memberId = memberId;
-        this.timetableId = timetableId;
-        this.createdAt = createdAt;
+    public TimetableFullResponseDto(Timetable table, List<ClassDto> classList,
+                                    List<CommentResponseDto> plusComments,
+                                    List<CommentResponseDto> minusComments,
+                                    List<CommentResponseDto> specialComments) {
+        this.memberId = table.getOwner().getMemberId();
+        this.timetableId = table.getTimetableId();
+        this.score = table.getScore();
+        this.tableType = table.getTableType();
+        this.tableTypeContent = table.getTableTypeContent();
+        this.classHide = table.isClassHide();
+        this.photo = table.getImgUrl();
+        this.createdAt = table.getCreatedAt();
         this.classList = classList;
+        this.plusComments = plusComments;
+        this.minusComments = minusComments;
+        this.specialComments = specialComments;
     }
 
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -7,6 +7,9 @@ import SamwaMoney.TimeTableArtist.Class.dto.ClassListDto;
 import SamwaMoney.TimeTableArtist.Class.dto.MoveDto;
 import SamwaMoney.TimeTableArtist.Class.repository.ClassRepository;
 import SamwaMoney.TimeTableArtist.Comment.Service.CommentService;
+import SamwaMoney.TimeTableArtist.Comment.dto.CommentResponseDto;
+import SamwaMoney.TimeTableArtist.Comment.entity.MinusComment;
+import SamwaMoney.TimeTableArtist.Comment.entity.PlusComment;
 import SamwaMoney.TimeTableArtist.Comment.entity.SpecialComment;
 import SamwaMoney.TimeTableArtist.Comment.repository.SpecialCommentRepository;
 import SamwaMoney.TimeTableArtist.Member.domain.Member;
@@ -16,10 +19,14 @@ import SamwaMoney.TimeTableArtist.TableLike.service.TableLikeService;
 import SamwaMoney.TimeTableArtist.Timetable.domain.Timetable;
 import SamwaMoney.TimeTableArtist.Timetable.dto.*;
 import SamwaMoney.TimeTableArtist.Timetable.repository.TimetableRepository;
+import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableMinusComment;
+import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TablePlusComment;
+import SamwaMoney.TimeTableArtist.tablecommentmap.domain.TableSpecialComment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityNotFoundException;
+import javax.xml.stream.events.Comment;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.List;
@@ -186,12 +193,30 @@ public class TimetableService {
         // timetableId를 기준으로, 이 시간표에 속한 모든 수업들의 정보를 담은 DTO 리스트 받아오기
         List<ClassDto> classList = classService.findClassesByTimetableId(timetableId);
 
+        // timeTable 객체에 있는 정보를 바탕으로, 해당하는 코멘트들의 내용 모두 불러오기
+        List<CommentResponseDto> plusComments = new ArrayList<>();
+        for(TablePlusComment t : timetable.getPlusComments()) {
+            PlusComment comment = t.getPlusComment();
+            plusComments.add(new CommentResponseDto(comment));
+        }
+        List<CommentResponseDto> minusComments = new ArrayList<>();
+        for(TableMinusComment t : timetable.getMinusComments()) {
+            MinusComment comment = t.getMinusComment();
+            minusComments.add(new CommentResponseDto(comment));
+        }
+        List<CommentResponseDto> specialComments = new ArrayList<>();
+        for(TableSpecialComment t : timetable.getSpecialComments()) {
+            SpecialComment comment = t.getSpecialComment();
+            specialComments.add(new CommentResponseDto(comment));
+        }
+
         // 찾아온 데이터를 DTO에 넣어 리턴
         return TimetableFullResponseDto.builder()
-                .memberId(timetable.getOwner().getMemberId())
-                .timetableId(timetable.getTimetableId())
-                .createdAt(timetable.getCreatedAt())
+                .table(timetable)
                 .classList(classList)
+                .plusComments(plusComments)
+                .minusComments(minusComments)
+                .specialComments(specialComments)
                 .build();
     }
 


### PR DESCRIPTION
# 구현 기능
- 내 시간표 조회의 응답 내용에 필요한 내용을 모두 추가하였습니다.
- '내 시간표 조회'와 '시간표 채점 결과 조회' 를 각각 다른 API로 설계한 상태였으나, 논의 결과 두 화면의 내용과 용도가 완전히 똑같다는 결론이 나왔습니다.
- 따라서 '내 시간표 조회' API의 응답에 필요한 모든 정보를 담고, '시간표 채점 결과 조회' API는 아예 없애기로 하였습니다. 이제 유저는 시간표 등록 직후 채점 결과를 볼 때와 햄버거 버튼에서 내 시간표 점수 보기를 눌렀을 때 완전히 같은 API를 호출하게 됩니다.

# 구현 상태
- 이전의 '내 시간표 조회' Response 모습: 
![image](https://github.com/SamwaMoney/Timetable-Artist-back/assets/87855493/7c16f7ce-58f8-4a1b-9074-685c502dd702)
memberId, timetableId, createdAt, classList만 있었음. 코멘트 정보는 아예 없는 상태임.<br><br>
- '시간표 채점 결과 조회' API 문서의 Response 모습
![image](https://github.com/SamwaMoney/Timetable-Artist-back/assets/87855493/49868295-0b33-4196-84ca-50ea1d78761a)
사진 정보, 코멘트 정보 등 '내 시간표 조회' 응답에 없는 내용이 몇 가지 들어가있지만 수업 리스트가 없는 상태임.<br><br>

- 수정 완료된 '내 시간표 조회' Response:
``` JSON
[
    "memberId" : 1,
    "timetableId" : 2,
    "score" : 76,
    "tableType" : 1,
    "tableTypeContent" : "등록금 뿌린 대로 거두자",
    "classHide" : 0,
    "photo" : "파일", // 이 시간표의 유형에 해당되는 스페셜 코멘트 짤의 URL
    "createdAt" : "2023-07-11T21:15:09.3987527",
    "classList" : [
        {
            "memberId" : 1,
            "table" : 2,  //이 수업이 속한 timetable의 Id
            "className" : "이펍의 이해",
            "location" : "ECC",
            "weekday" : "월",
            "startH" : 9,
            "startM" : 30,
            "endH" : 11,
            "endM" : 0
        },
        {
            "memberId" : 1,
            "table" : 2,
            "className" : "이펍의 이해",
            "location" : "ECC",
            "weekday" : "수",
            "startH" : 11,
            "startM" : 0,
            "endH" : 12,
            "endM" : 30
        },
        {
            "memberId" : 1,
            "table" : 2,
            "className" : "SWS의 이해",
            "location" : "공학관",
            "weekday" : "화",
            "startH" : 11,
            "startM" : 0,
            "endH" : 12,
            "endM" : 30
        },
        {
            "memberId" : 1,
            "table" : 2,
            "className" : "SWS의 이해",
            "location" : "공학관",
            "weekday" : "목",
            "startH" : 11,
            "startM" : 0,
            "endH" : 12,
            "endM" : 30
        }
		],
    "plusComments" : [
        {
            "commentType" : "plus",
            "commentId" : 1,
            "content" : ""
        },
        {
            "commentType" : "plus",
            "commentId" : 2,
            "content" : ""
        }
    "minusComments" : [
        {
            "commentType" : "minus",
            "commentId" : 4,
            "content" : ""
        },
        {
            "commentType" : "minus",
            "commentId" : 5,
            "content" : ""
        }
    ],
    "specialComments" : [
        {
            "commentType" : "special",
            "commentId" : 1,
            "content" : "  "
        },
        {
            "commentType" : "special",
            "commentId" : 12,
            "content" : ""
        }
    ]    
]
```
화면 표시에 필요한 모든 정보가 포함된 상태입니다.
위부터 차례대로,
작성자 ID, 시간표 ID, 점수, 시간표 유형에 해당하는 스페셜 코멘트의 ID, 시간표 유형에 해당하는 스페셜 코멘트의 내용, 수업명 숨기기 여부, 유형 짤 URL, 시간표 생성일자, 수업 목록, plus 코멘트 목록, minus 코멘트 목록, special 코멘트 목록

- 구현 방법은 이렇습니다. 세 가지 파일만 변경되었습니다.
1. 원래 '내 시간표 조회' 응답용으로 사용되던 TimetableFullResponseDto.java 를 수정하여 응답 내용을 추가함.
2. TimetableFullRespnseDto 내부에서 코멘트 리스트를 구성하기 위해, 리스트의 내용물로 쓰일 CommentResponseDto.java 를 새로 만듦.
3. 달라진 Dto에 적합하도록 TimetableService.java를 수정함.