### PR TITLE
[차소연] fix: 댓글 조회, 시간표 좋아요 URI 수정

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/controller/ReplyController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/controller/ReplyController.java
@@ -32,8 +32,7 @@ public class ReplyController {
     // 특정 시간표 댓글 목록 조회
     @GetMapping("/timetables/{timetableId}/replies")
     @ResponseStatus(code = HttpStatus.OK)
-    public TimetableRepliesResponseDto readTimetableReplies(@PathVariable Long timetableId, @RequestBody HeartRequestDto requestDto){
-        Long memberId = requestDto.getMemberId();
+    public TimetableRepliesResponseDto readTimetableReplies(@PathVariable Long timetableId, @RequestParam(value = "memberId") Long memberId){
         List<Reply> replyList = replyService.findReplyListByTimetable(timetableId);
         if (memberId != null){
             for (Reply reply : replyList)

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/controller/TableLikeController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/TableLike/controller/TableLikeController.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/tables/{timetable_id}/likes")
+@RequestMapping("/timetables/{timetable_id}/likes")
 @RequiredArgsConstructor
 public class TableLikeController {
 

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/controller/TimetableController.java
@@ -29,8 +29,6 @@ import java.util.List;
 public class TimetableController {
 
     private final TimetableService timetableService;
-    private final TimetableRepository timetableRepository;
-    private final ClassService classService;
     private final TableLikeService tableLikeService;
     private final S3Uploader s3Uploader;
 


### PR DESCRIPTION
# 구현 기능
- 댓글 get에서 request body로 memberId 전달이 불가능해서 request param을 이용하는 방식으로 바꿨습니다.
- timetableLikeController에서 URI가 mysql에서 "table"관련 오류가 나기 전의 API대로 반영이 되어 있어 URI의 'tables'를 'timetables'로 고쳤습니다.