### PR TITLE
[차소연] 내 시간표 조회에 replyCount 추가, 댓글 개수 업데이트 코드 추가

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/repository/ReplyRepository.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/repository/ReplyRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
     List<Reply> findAllByTimetableOrderByReplyLikeCountDesc(Timetable timetable);
+    Integer countByTimetable(Timetable timetable);
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/service/ReplyService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/service/ReplyService.java
@@ -34,9 +34,14 @@ public class ReplyService {
         boolean nameHide = requestDto.isNameHide();
         String name = writer.getUsername();
         String replyName = selectName(nameHide, name);
+        Long replyCount = timetable.getReplyCount();
 
         boolean isHeart = false;
         Integer replyLikeCount = 0;
+
+        Long newReplyCount = replyCount + 1;
+        timetable.updateReplyCount(newReplyCount);
+
         return replyRepository.save(requestDto.toEntity(timetable, writer, replyName, isHeart, replyLikeCount)).getReplyId();
     }
 
@@ -65,6 +70,15 @@ public class ReplyService {
     public void removeReply(Long replyId){
         Reply reply = findReplyById(replyId);
         replyRepository.delete(reply);
+        Timetable timetable = reply.getTimetable();
+        Integer replyCount = getReplyCount(timetable);
+        timetable.updateReplyCount(Long.valueOf(replyCount));
+    }
+
+    @Transactional (readOnly = true)
+    public Integer getReplyCount(Timetable timetable) {
+        Integer replyCount = replyRepository.countByTimetable(timetable);
+        return replyCount;
     }
 }
 

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/domain/Timetable.java
@@ -113,4 +113,8 @@ public class Timetable extends BaseTimeEntity {
         this.imgUrl = fileUrl;
         this.tableTypeContent = tableTypeContent;
     }
+
+    public void updateReplyCount(Long newReplyCount){
+        this.replyCount = newReplyCount;
+    }
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/dto/TimetableFullResponseDto.java
@@ -29,13 +29,14 @@ public class TimetableFullResponseDto {
     private String owner;
     private Long likeCount;
     private boolean isLiked;
+    private Long replyCount;
 
 
     @Builder
     public TimetableFullResponseDto(Timetable table, List<ClassDto> classList,
                                     List<CommentResponseDto> plusComments,
                                     List<CommentResponseDto> minusComments,
-                                    List<CommentResponseDto> specialComments, String owner, Long likeCount, boolean isLiked) {
+                                    List<CommentResponseDto> specialComments, String owner, Long likeCount, boolean isLiked, Long replyCount) {
         this.memberId = table.getOwner().getMemberId();
         this.timetableId = table.getTimetableId();
         this.score = table.getScore();
@@ -51,6 +52,6 @@ public class TimetableFullResponseDto {
         this.owner = owner;
         this.likeCount = likeCount;
         this.isLiked = isLiked;
+        this.replyCount = replyCount;
     }
-
 }

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -229,6 +229,7 @@ public class TimetableService {
                 .owner(timetable.getOwner().getUsername())
                 .likeCount(timetable.getLikeCount())
                 .isLiked(isLiked)
+                .replyCount(timetable.getReplyCount())
                 .build();
     }
 


### PR DESCRIPTION
# 구현 기능
- '내 시간표 조회' 기능에서 시간표의 댓글 개수도 조회되도록 dto에 replyCount 추가
- 댓글 생성, 삭제시 댓글 개수 업데이트 코드 추가
<img width="634" alt="스크린샷 2023-07-31 185534" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/89539031/f9d2dfcd-ca8b-4838-a432-0a93b45fc7ed">
