### PR TITLE
[차소연] 로그인 안 한 경우 memberId로 받을 값 변경

### DIFF
--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/controller/ReplyController.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Reply/controller/ReplyController.java
@@ -34,7 +34,7 @@ public class ReplyController {
     @ResponseStatus(code = HttpStatus.OK)
     public TimetableRepliesResponseDto readTimetableReplies(@PathVariable Long timetableId, @RequestParam(value = "memberId") Long memberId){
         List<Reply> replyList = replyService.findReplyListByTimetable(timetableId);
-        if (memberId != null){
+        if (memberId != -1){
             for (Reply reply : replyList)
             {
                 reply.heart = replyLikeService.isHeart(memberId, reply);

--- a/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
+++ b/TimeTableArtist/src/main/java/SamwaMoney/TimeTableArtist/Timetable/service/TimetableService.java
@@ -269,7 +269,7 @@ public class TimetableService {
             long likeCount = tableLikeService.getLikeCount(timetable.getTimetableId());
             boolean isLiked = false;
 
-            if (memberId != null) {
+            if (memberId != -1) {
                 isLiked = tableLikeService.isTimetableLikedByMember(timetable.getTimetableId(), memberId);
             }
             responseList.add(RankingboardGetResponseDto.from(timetable, likeCount, isLiked));


### PR DESCRIPTION
# 구현 기능
- 조회 기능에서 memberId를 받는 방식이 RequestParam으로 바뀜에 따라 memberId를 null로 받을 수 없게 되어 로그인 하지 않는 경우 memberId는 -1로 받는 것으로 변경되었습니다.
<img width="639" alt="image" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/89539031/4730cf9a-9832-4d2d-8b82-c7a97cdf5e13">
<img width="635" alt="스크린샷 2023-08-01 004529" src="https://github.com/SamwaMoney/Timetable-Artist-back/assets/89539031/be804cc0-bf45-4c65-8589-060574506b7e">